### PR TITLE
Removed tags in all alerts

### DIFF
--- a/api_management/main.tf
+++ b/api_management/main.tf
@@ -184,8 +184,6 @@ resource "azurerm_monitor_metric_alert" "this" {
 
     }
   }
-
-  tags = var.tags
 }
 
 

--- a/eventhub/main.tf
+++ b/eventhub/main.tf
@@ -172,6 +172,4 @@ resource "azurerm_monitor_metric_alert" "this" {
       }
     }
   }
-
-  tags = var.tags
 }

--- a/kubernetes_cluster/main.tf
+++ b/kubernetes_cluster/main.tf
@@ -133,6 +133,4 @@ resource "azurerm_monitor_metric_alert" "this" {
       }
     }
   }
-
-  tags = var.tags
 }

--- a/postgresql_server/main.tf
+++ b/postgresql_server/main.tf
@@ -232,8 +232,6 @@ resource "azurerm_monitor_metric_alert" "this" {
       }
     }
   }
-
-  tags = var.tags
 }
 
 
@@ -273,8 +271,6 @@ resource "azurerm_monitor_metric_alert" "replica" {
       }
     }
   }
-
-  tags = var.tags
 }
 
 


### PR DESCRIPTION
These tags sometimes result always not aligned after the apply: keys on the portal are saved in camel case format even if on the code they are not. 