### PR TITLE
[CEN-787] Allow to configure a max_pods per agent

### DIFF
--- a/kubernetes_cluster/main.tf
+++ b/kubernetes_cluster/main.tf
@@ -17,6 +17,7 @@ resource "azurerm_kubernetes_cluster" "this" {
     node_count          = var.node_count
     min_count           = var.min_count
     max_count           = var.max_count
+    max_pods            = var.max_pods
 
     upgrade_settings {
       max_surge = var.upgrade_settings_max_surge

--- a/kubernetes_cluster/variables.tf
+++ b/kubernetes_cluster/variables.tf
@@ -131,6 +131,12 @@ variable "max_count" {
   default     = null
 }
 
+variable "max_pods" {
+  type        = number
+  description = "The maximum number of pods that can run on each agent. Changing this forces a new resource to be created."
+  default     = 30
+}
+
 variable "upgrade_settings_max_surge" {
   type        = string
   description = "The maximum number or percentage of nodes which will be added to the Node Pool size during an upgrade."


### PR DESCRIPTION
## Description
This PR proposes to expose a TF variable to configure the maximum number of pods allowed for an agent in a node pool of a k8s cluster. The default of `30` could be a bit limiting for low resource environments like `dev`