### PR TITLE
[CEN-828] Refactor Eventhub Module

### DIFF
--- a/eventhub/outputs.tf
+++ b/eventhub/outputs.tf
@@ -24,3 +24,11 @@ output "keys" {
     }
   }
 }
+
+output "private_dns_zone" {
+  description = "ID of the private DNS zone which resolves the name of the Private Endpoint used to connect to EventHub"
+  value =  {
+    id = azurerm_private_dns_zone.eventhub.*.id
+    name = azurerm_private_dns_zone.eventhub.*.name
+  }
+}

--- a/eventhub/variables.tf
+++ b/eventhub/variables.tf
@@ -132,6 +132,26 @@ variable "alerts_enabled" {
   description = "Should Metrics Alert be enabled?"
 }
 
+# If this variable contains empty arrays as in the default value a new private DNS Zone will be created
+variable "private_dns_zones" {
+  description = "Private DNS Zones where the private endpoint will be created"
+  type = object({
+    id = list(string)
+    name = list(string)
+  })
+  default = {
+    id = []
+    name = []
+  }
+}
+
+variable private_dns_zone_record_A_name {
+  description = "Name of the A record in the private dns zone"
+  type = string
+  default = "eventhub"
+
+}
+
 variable "tags" {
   type = map(any)
 }


### PR DESCRIPTION
## Description

This PR proposes to refactor the EventHub module in order to be able to pass an existing Private DNS Zone as input.
The problem with the current module arise because of the following reasons 
- an EventHub Namespace with a `Standard` SKU  supports only 10 event hubs, but the `cstar` applications FA + BDP + RTD need more. Switching to the `Premium` SKU should be avoided, due to a 10x cost compared to the `Standard` SKU
- In order to avoid IP waste & consumption in critical subnet, all EventHub namespace must be accessible through a Private Endpoint with an IP taken from the dedicated subnet in `vnet-integration`

The proposed solution tries to be **backward compatible** so as to avoid messing up with Terraform resources and getting a new connection string for the existing Namespace `eventhub`, thus eliminating the necessity to upgrade the `CSV Connector` in PCI-DSS portion of the infrastructure. It makes the creation of a new Private DNS Zone _optional_ thus supporting the following _chaining_ pattern in event hub namespaces provisioning

```
module "event_hub" {
    ...
}

module "event_hub_01" {
    ...
    private_dns_zones              = module.event_hub.private_dns_zone
    private_dns_zone_record_A_name = "eventhub01"
}
```
The customization of the A record isn't strictly a necessity, but I preferred to keep it for backward compatibility
Usage example here: https://github.com/pagopa/cstar-infrastructure/pull/228