### PR TITLE
Add tags to Azure Container Registry resource

### DIFF
--- a/container_registry/main.tf
+++ b/container_registry/main.tf
@@ -4,7 +4,7 @@ resource "azurerm_container_registry" "this" {
   location            = var.location
   sku                 = var.sku
   admin_enabled       = var.admin_enabled
-
+  tags                = var.tags
 
   dynamic "georeplications" {
     for_each = var.georeplications


### PR DESCRIPTION
Hello!

I noticed that tags are not applied to ACR main resource when the `georeplication` (an optional feature) is not enabled. I added them with this PR.