### PR TITLE
Cen 1033 ignore changes on aks node count

### DIFF
--- a/kubernetes_cluster/main.tf
+++ b/kubernetes_cluster/main.tf
@@ -85,6 +85,12 @@ resource "azurerm_kubernetes_cluster" "this" {
     }
   }
 
+  lifecycle {
+    ignore_changes = [
+      default_node_pool.node_count,
+    ]
+  }
+
   tags = var.tags
 }
 

--- a/kubernetes_cluster/main.tf
+++ b/kubernetes_cluster/main.tf
@@ -87,7 +87,7 @@ resource "azurerm_kubernetes_cluster" "this" {
 
   lifecycle {
     ignore_changes = [
-      default_node_pool.node_count,
+      default_node_pool[0].node_count,
     ]
   }
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to add an `ignore_changes` lifecycle block to avoid mismatch between `node_count` and the number of nodes computed by the cluster autoscaler, as suggested by [doc](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_cluster#default_node_pool)


### List of changes

<!--- Describe your changes in detail -->

- `ignore_changes` [lifecycle block](https://www.terraform.io/docs/language/meta-arguments/lifecycle.html?_ga=2.70378009.804897527.1637247475-218636416.1625737473#ignore_changes) to guarantee that `node_count` is set when the resource is created, then ignored 

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

If the cluster autoscaler is enabled, the number of nodes computed by the autoscaling policy can be different from the value set in `node_count`, so `node_count` would override the _right_ number of nodes.
On the other hand, if the autoscaler is disabled, the number of nodes should be known in advance and never changed, otherwise it would be better to enable autoscaling. 

### Type of changes

- [ ] Add new module
- [x] Update existing module
- [ ] Remove existing module

### Does this introduce a breaking change?

- [x] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
