### PR TITLE
Fix webtest

### DIFF
--- a/application_insights_web_test_preview/main.tf
+++ b/application_insights_web_test_preview/main.tf
@@ -34,16 +34,17 @@ resource "azurerm_monitor_metric_alert" "this" {
   severity            = var.severity
   scopes = [
     data.azurerm_application_insights.this.id,
-    format("/subscriptions/%s/resourcegroups/%s/providers/microsoft.insights/webtests/%s-%s",
+    format("/subscriptions/%s/resourcegroups/%s/providers/microsoft.insights/webTests/%s-%s",
       var.subscription_id,
       var.resource_group,
       var.name,
-    var.application_insight_name),
+      var.application_insight_name
+    ),
   ]
   description = "Web availability check alert triggered when it fails."
 
   application_insights_web_test_location_availability_criteria {
-    web_test_id = format("/subscriptions/%s/resourcegroups/%s/providers/microsoft.insights/webtests/%s-%s",
+    web_test_id = format("/subscriptions/%s/resourcegroups/%s/providers/microsoft.insights/webTests/%s-%s",
       var.subscription_id,
       var.resource_group,
       var.name,


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

use webTests case sensitive value

`"/subscriptions/%s/resourcegroups/%s/providers/microsoft.insights/webTests/%s-%s"`

### Motivation and context

```
Error: ID was missing the `webTests` element
│ 
│   with module.web_test_api["SpidL2-spiditalia"].azurerm_monitor_metric_alert.this,
│   on .terraform/modules/web_test_api/application_insights_web_test_preview/main.tf line 46, in resource "azurerm_monitor_metric_alert" "this":
│   46:     web_test_id = format("/subscriptions/%s/resourcegroups/%s/providers/microsoft.insights/webtests/%s-%s",
│   47:       var.subscription_id,
│   48:       var.resource_group,
│   49:       var.name,
│   50:       var.application_insight_name
│   51:     )
│ 
```

### Type of changes

- [ ] Add new module
- [x] Update existing module
- [ ] Remove existing module

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
