### PR TITLE
fix(application_insights_web_test): Change default auto_mitigate to false

### DIFF
--- a/application_insights_web_test_preview/README.md
+++ b/application_insights_web_test_preview/README.md
@@ -1,12 +1,8 @@
+<!-- markdownlint-disable -->
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 
 No requirements.
-
-## Providers
-
-| Name | Version |
-|------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | n/a |
 
 ## Modules
 
@@ -26,19 +22,22 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_actions"></a> [actions](#input\_actions) | n/a | <pre>list(object({<br>    action_group_id = string<br>  }))</pre> | n/a | yes |
 | <a name="input_application_insight_name"></a> [application\_insight\_name](#input\_application\_insight\_name) | Application insight instance name. | `string` | n/a | yes |
-| <a name="input_location"></a> [location](#input\_location) | Application insight location. | `string` | n/a | yes |
-| <a name="input_name"></a> [name](#input\_name) | (Required) Web test name | `string` | n/a | yes |
-| <a name="input_request_url"></a> [request\_url](#input\_request\_url) | Url to check. | `string` | n/a | yes |
-| <a name="input_resource_group"></a> [resource\_group](#input\_resource\_group) | Resource group name | `string` | n/a | yes |
-| <a name="input_subscription_id"></a> [subscription\_id](#input\_subscription\_id) | (Required) subscription id. | `string` | n/a | yes |
+| <a name="input_auto_mitigate"></a> [auto\_mitigate](#input\_auto\_mitigate) | (Optional) Should the alerts in this Metric Alert be auto resolved? Defaults to false. | `bool` | `false` | no |
+| <a name="input_content_validation"></a> [content\_validation](#input\_content\_validation) | Required text that should appear in the response for this WebTest. | `string` | `null` | no |
 | <a name="input_expected_http_status"></a> [expected\_http\_status](#input\_expected\_http\_status) | Expeced http status code. | `number` | `200` | no |
 | <a name="input_failed_location_count"></a> [failed\_location\_count](#input\_failed\_location\_count) | The number of failed locations. | `number` | `1` | no |
 | <a name="input_frequency"></a> [frequency](#input\_frequency) | Interval in seconds between test runs for this WebTest. | `number` | `300` | no |
 | <a name="input_ignore_http_status"></a> [ignore\_http\_status](#input\_ignore\_http\_status) | Ignore http status code. | `bool` | `false` | no |
+| <a name="input_location"></a> [location](#input\_location) | Application insight location. | `string` | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | (Required) Web test name | `string` | n/a | yes |
+| <a name="input_request_url"></a> [request\_url](#input\_request\_url) | Url to check. | `string` | n/a | yes |
+| <a name="input_resource_group"></a> [resource\_group](#input\_resource\_group) | Resource group name | `string` | n/a | yes |
 | <a name="input_severity"></a> [severity](#input\_severity) | The severity of this Metric Alert. | `number` | `1` | no |
 | <a name="input_ssl_cert_remaining_lifetime_check"></a> [ssl\_cert\_remaining\_lifetime\_check](#input\_ssl\_cert\_remaining\_lifetime\_check) | Days before the ssl certificate will expire. An expiry certificate will cause the test failing. | `number` | `7` | no |
+| <a name="input_subscription_id"></a> [subscription\_id](#input\_subscription\_id) | (Required) subscription id. | `string` | n/a | yes |
 | <a name="input_timeout"></a> [timeout](#input\_timeout) | Seconds until this WebTest will timeout and fail. | `number` | `30` | no |
 
 ## Outputs
 
 No outputs.
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/application_insights_web_test_preview/main.tf
+++ b/application_insights_web_test_preview/main.tf
@@ -42,7 +42,8 @@ resource "azurerm_monitor_metric_alert" "this" {
       var.application_insight_name
     ),
   ]
-  description = "Web availability check alert triggered when it fails."
+  description   = "Web availability check alert triggered when it fails."
+  auto_mitigate = var.auto_mitigate
 
   application_insights_web_test_location_availability_criteria {
     web_test_id = format("/subscriptions/%s/resourcegroups/%s/providers/microsoft.insights/webTests/%s-%s",

--- a/application_insights_web_test_preview/variables.tf
+++ b/application_insights_web_test_preview/variables.tf
@@ -51,7 +51,12 @@ variable "ignore_http_status" {
   type        = bool
   description = "Ignore http status code."
   default     = false
+}
 
+variable "auto_mitigate" {
+  type        = bool
+  description = "(Optional) Should the alerts in this Metric Alert be auto resolved? Defaults to false."
+  default     = false
 }
 
 variable "ssl_cert_remaining_lifetime_check" {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

Change default auto_mitigate to false

### Motivation and context

With auto_mitigate=true we will receive only the first alert, we want to receive alerts until the test fails.

### Type of changes

- [ ] Add new module
- [x] Update existing module
- [ ] Remove existing module

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
