### PR TITLE
fix(app_gateway): Use only GCM ciphersuites

### DIFF
--- a/app_gateway/main.tf
+++ b/app_gateway/main.tf
@@ -254,8 +254,6 @@ resource "azurerm_application_gateway" "this" {
     cipher_suites = [
       "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
       "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
-      "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
-      "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA"
     ]
     min_protocol_version = "TLSv1_2"
   }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

Remove CBC ciphersuites and use only GCM ciphersuites

### Motivation and context

Main pull request from dismissed repo:
https://github.com/pagopa/io-infrastructure-modules-new/pull/241

### Type of changes

- [ ] Add new module
- [x] Update existing module
- [ ] Remove existing module

### Does this introduce a breaking change?

- [x] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

### Run checks

Useful commands to run checks on local machine

```sh
bash .utils/terraform_run_all.sh init local
pre-commit run -a
```
