### PR TITLE
[IID-10] Use CDN managed custom certificate

### DIFF
--- a/cdn/main.tf
+++ b/cdn/main.tf
@@ -520,12 +520,7 @@ resource "null_resource" "custom_domain" {
         --endpoint-name ${self.triggers.endpoint_name} \
         --profile-name ${self.triggers.profile_name} \
         --name ${replace(self.triggers.name, ".", "-")} \
-        --min-tls-version "1.2" \
-        --user-cert-protocol-type sni \
-        --user-cert-group-name ${self.triggers.keyvault_resource_group_name} \
-        --user-cert-vault-name ${self.triggers.keyvault_vault_name} \
-        --user-cert-secret-name ${replace(self.triggers.name, ".", "-")} \
-        --user-cert-subscription-id  ${self.triggers.keyvault_subscription_id}
+        --min-tls-version "1.2" 
     EOT
   }
   # https://docs.microsoft.com/it-it/cli/azure/cdn/custom-domain?view=azure-cli-latest

--- a/cdn/main.tf
+++ b/cdn/main.tf
@@ -555,20 +555,6 @@ resource "azurerm_dns_a_record" "hostname" {
   tags = var.tags
 }
 
-# record A
-resource "azurerm_dns_a_record" "hostname_a" {
-  # create this iff DNS zone name equal to HOST NAME azurerm_cdn_endpoint.this.host_name
-  # true if ex: dns_zone_name = dev.pagopa.it, hostname = west.dev.pagopa.it
-  count = length(split(var.dns_zone_name, var.hostname)) > 1 ? 1 : 0
-
-  name                = trimsuffix(trimsuffix(var.hostname, var.dns_zone_name), ".")
-  zone_name           = var.dns_zone_name
-  resource_group_name = var.dns_zone_resource_group_name
-  ttl                 = 3600
-  target_resource_id  = azurerm_cdn_endpoint.this.id
-
-  tags = var.tags
-}
 
 # https://docs.microsoft.com/en-us/azure/dns/dns-custom-domain#azure-cdn
 resource "azurerm_dns_cname_record" "cdnverify" {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

This PR proposes to use a CDN managed custom certificate and only a CNAME DNS record to expose a CDN endpoint in certain cases.

### List of changes

<!--- Describe your changes in detail -->

- Remove the need to set a custom certificate
- Remove the need to expose a CDN endpoint via an A record

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

This PR is motivated by the need to simplify exposure of CDN endpoints. 
Since an A record is not strictly needed to expose the endpoint and the CDN could automatically manage the release of a Digicert certificate, such simplifications could be exploited

### Type of changes

- [ ] Add new module
- [ ] Update existing module
- [ ] Remove existing module

### Does this introduce a breaking change?

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

### Run checks

Useful commands to run checks on local machine

```sh
bash .utils/terraform_run_all.sh init local
pre-commit run -a
```
