### PR TITLE
fix: Mongodb collection added ignore value to autoscale_settings

### DIFF
--- a/cosmosdb_mongodb_collection/README.md
+++ b/cosmosdb_mongodb_collection/README.md
@@ -1,6 +1,10 @@
 # MongoDB Collection
 
-This module allow the creation of a collection inside a MongoDB database
+This module allow the creation of a collection inside a MongoDB database.
+
+## Limits
+
+`autoscale_settings` are ignored in lifecycle to allow a external configuration to be done
 
 ## Architecture
 

--- a/cosmosdb_mongodb_collection/main.tf
+++ b/cosmosdb_mongodb_collection/main.tf
@@ -20,6 +20,13 @@ resource "azurerm_cosmosdb_mongo_collection" "this" {
     }
   }
 
+  lifecycle {
+    ignore_changes = [
+      # ignore changes to autoscale_settings due to this operation is done manually
+      autoscale_settings,
+    ]
+  }
+
   dynamic "autoscale_settings" {
     for_each = var.max_throughput == null ? [] : ["dummy"]
     content {
@@ -33,6 +40,7 @@ resource "azurerm_cosmosdb_mongo_collection" "this" {
     read   = var.timeout_read
     delete = var.timeout_delete
   }
+
 }
 
 resource "azurerm_management_lock" "this" {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

Added ignore value in autoscale_settings

### Motivation and context

Allow to manage the autoscale setting of the mongodb collection manually to improve the cost search

### Type of changes

- [ ] Add new module
- [x] Update existing module
- [ ] Remove existing module

### Does this introduce a breaking change?

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

### Run checks

Useful commands to run checks on local machine

```sh
bash .utils/terraform_run_all.sh init local
pre-commit run -a
```
