### PR TITLE
fix: Update `storage_account_low_availability` metric with new metric_namespace

### DIFF
--- a/storage_account/main.tf
+++ b/storage_account/main.tf
@@ -116,9 +116,9 @@ resource "azurerm_monitor_metric_alert" "storage_account_low_availability" {
   auto_mitigate       = false
 
   # Metric info
-  # https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftclassicstoragestorageaccountsblobservices
+  # https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftstoragestorageaccounts
   criteria {
-    metric_namespace       = "Microsoft.ClassicStorage/storageAccounts"
+    metric_namespace       = "Microsoft.Storage/storageAccounts"
     metric_name            = "Availability"
     aggregation            = "Average"
     operator               = "LessThan"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

Update `storage_account_low_availability` metric with new metric_namespace after testing it in https://github.com/pagopa/io-infra/pull/338

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new module
- [x] Update existing module
- [ ] Remove existing module

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

### Run checks

Useful commands to run checks on local machine

```sh
bash .utils/terraform_run_all.sh init local
pre-commit run -a
```
