### PR TITLE
breaking: Storage account versioning upgraded

### DIFF
--- a/storage_account/README.md
+++ b/storage_account/README.md
@@ -17,7 +17,6 @@ module "selc-contracts-storage" {
   account_tier               = "Standard"
   account_replication_type   = var.contracts_account_replication_type
   access_tier                = "Hot"
-  versioning_name            = "versioning"
   enable_versioning          = var.contracts_enable_versioning
   resource_group_name        = azurerm_resource_group.rg_contracts_storage.name
   location                   = var.location
@@ -30,6 +29,10 @@ module "selc-contracts-storage" {
 }
 
 ```
+
+## 🔥 Breaking change
+
+* removed `versioning_name` attribute, please remove from the definition
 
 <!-- markdownlint-disable -->
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
@@ -58,7 +61,6 @@ No modules.
 | [azurerm_management_lock.management_lock](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/management_lock) | resource |
 | [azurerm_monitor_metric_alert.storage_account_low_availability](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_metric_alert) | resource |
 | [azurerm_storage_account.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account) | resource |
-| [azurerm_template_deployment.versioning](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/template_deployment) | resource |
 
 ## Inputs
 
@@ -91,7 +93,6 @@ No modules.
 | <a name="input_network_rules"></a> [network\_rules](#input\_network\_rules) | n/a | <pre>object({<br>    default_action             = string       # Specifies the default action of allow or deny when no other rules match. Valid options are Deny or Allow<br>    bypass                     = set(string)  # Specifies whether traffic is bypassed for Logging/Metrics/AzureServices. Valid options are any combination of Logging, Metrics, AzureServices, or None<br>    ip_rules                   = list(string) # List of public IP or IP ranges in CIDR Format. Only IPV4 addresses are allowed<br>    virtual_network_subnet_ids = list(string) # A list of resource ids for subnets.<br>  })</pre> | `null` | no |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | n/a | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | n/a | `map(any)` | n/a | yes |
-| <a name="input_versioning_name"></a> [versioning\_name](#input\_versioning\_name) | n/a | `string` | `null` | no |
 
 ## Outputs
 

--- a/storage_account/main.tf
+++ b/storage_account/main.tf
@@ -21,6 +21,13 @@ resource "azurerm_storage_account" "this" {
     }
   }
 
+  dynamic "blob_properties" {
+    for_each = var.enable_versioning ? [] : ["dummy"]
+    content {
+      versioning_enabled = var.enable_versioning
+    }
+  }
+
   dynamic "network_rules" {
     for_each = var.network_rules == null ? [] : [var.network_rules]
 
@@ -80,7 +87,8 @@ resource "azurerm_template_deployment" "versioning" {
                 "storageAccount": {
                     "type": "string",
                     "metadata": {
-                        "description": "Storage Account Name"}
+                        "description": "Storage Account Name"
+                    }
                 }
             },
             "variables": {},

--- a/storage_account/main.tf
+++ b/storage_account/main.tf
@@ -12,18 +12,15 @@ resource "azurerm_storage_account" "this" {
   allow_blob_public_access  = var.allow_blob_public_access
   is_hns_enabled            = var.is_hns_enabled
 
-  dynamic "blob_properties" {
-    for_each = var.blob_properties_delete_retention_policy_days == null ? [] : ["dummy"]
-    content {
-      delete_retention_policy {
-        days = var.blob_properties_delete_retention_policy_days
-      }
-    }
-  }
-
-  dynamic "blob_properties" {
+  dynamic "blob_properties"{
     for_each = ["dummy"]
     content {
+      dynamic "delete_retention_policy" {
+        for_each = var.blob_properties_delete_retention_policy_days == null ? [] : ["dummy"]
+        content {
+          days = var.blob_properties_delete_retention_policy_days
+        }
+      }
       versioning_enabled = true
     }
   }

--- a/storage_account/main.tf
+++ b/storage_account/main.tf
@@ -22,9 +22,9 @@ resource "azurerm_storage_account" "this" {
   }
 
   dynamic "blob_properties" {
-    for_each = var.enable_versioning ? [] : ["dummy"]
+    for_each = ["dummy"]
     content {
-      versioning_enabled = var.enable_versioning
+      versioning_enabled = true
     }
   }
 

--- a/storage_account/main.tf
+++ b/storage_account/main.tf
@@ -12,7 +12,7 @@ resource "azurerm_storage_account" "this" {
   allow_blob_public_access  = var.allow_blob_public_access
   is_hns_enabled            = var.is_hns_enabled
 
-  dynamic "blob_properties"{
+  dynamic "blob_properties" {
     for_each = ["dummy"]
     content {
       dynamic "delete_retention_policy" {

--- a/storage_account/main.tf
+++ b/storage_account/main.tf
@@ -63,46 +63,6 @@ resource "azurerm_advanced_threat_protection" "this" {
   enabled            = var.advanced_threat_protection
 }
 
-# this is a tempory implementation till an official one will be released:
-# https://github.com/terraform-providers/terraform-provider-azurerm/issues/8268
-resource "azurerm_template_deployment" "versioning" {
-  count      = var.enable_versioning ? 1 : 0
-  depends_on = [azurerm_storage_account.this]
-
-  name                = var.versioning_name
-  resource_group_name = var.resource_group_name
-  deployment_mode     = "Incremental"
-  parameters = {
-    "storageAccount" = azurerm_storage_account.this.name
-  }
-
-  template_body = <<DEPLOY
-        {
-            "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-            "contentVersion": "1.0.0.0",
-            "parameters": {
-                "storageAccount": {
-                    "type": "string",
-                    "metadata": {
-                        "description": "Storage Account Name"
-                    }
-                }
-            },
-            "variables": {},
-            "resources": [
-                {
-                    "type": "Microsoft.Storage/storageAccounts/blobServices",
-                    "apiVersion": "2019-06-01",
-                    "name": "[concat(parameters('storageAccount'), '/default')]",
-                    "properties": {
-                        "IsVersioningEnabled": ${var.enable_versioning}
-                    }
-                }
-            ]
-        }
-    DEPLOY
-}
-
 resource "azurerm_management_lock" "management_lock" {
   count      = var.lock_enabled ? 1 : 0
   depends_on = [azurerm_storage_account.this]

--- a/storage_account/variables.tf
+++ b/storage_account/variables.tf
@@ -88,13 +88,6 @@ variable "enable_versioning" {
   description = "Enable versioning in the blob storage account."
 }
 
-# versioning
-
-variable "versioning_name" {
-  type    = string
-  default = null
-}
-
 # lock
 
 variable "lock_enabled" {


### PR DESCRIPTION
### :warning: This repo is stale, all new features will be added on https://github.com/pagopa/terraform-azurerm-v3 :warning:

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

- Now use the attribute versioning, and not more the arm json
- removed versioning_name as attribute 

### Motivation and context

Now is possible to use `blob_properties_delete_retention_policy_days` and `versioning` at the same time.

### Type of changes

- [ ] Add new module
- [x] Update existing module
- [ ] Remove existing module

### Does this introduce a breaking change?

- [x] Yes
- [ ] No

### Other information

Check documentation, because is mandatory to not use the parameter `versioning_name` to avoid errors during apply

### Run checks

Useful commands to run checks on local machine

```sh
bash .utils/terraform_run_all.sh init local
pre-commit run -a
```
