### PR TITLE
feat: ELK added ingressClassName

### DIFF
--- a/elastic_stack/yaml/ingress_apm.yaml
+++ b/elastic_stack/yaml/ingress_apm.yaml
@@ -9,6 +9,7 @@ metadata:
     nginx.ingress.kubernetes.io/ssl-redirect: 'false'
     nginx.ingress.kubernetes.io/use-regex: 'true'
 spec:
+  ingressClassName: nginxelk
   tls:
     - hosts:
         - ${kibana_internal_hostname}

--- a/elastic_stack/yaml/ingress_elastic.yaml
+++ b/elastic_stack/yaml/ingress_elastic.yaml
@@ -12,6 +12,7 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-ssl-verify: "false"
     nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
 spec:
+  ingressClassName: nginxelk
   tls:
     - hosts:
         - ${kibana_internal_hostname}

--- a/elastic_stack/yaml/ingress_kibana.yaml
+++ b/elastic_stack/yaml/ingress_kibana.yaml
@@ -9,6 +9,7 @@ metadata:
     nginx.ingress.kubernetes.io/ssl-redirect: 'false'
     nginx.ingress.kubernetes.io/use-regex: 'true'
 spec:
+  ingressClassName: nginxelk
   tls:
     - hosts:
         - ${kibana_internal_hostname}


### PR DESCRIPTION
### :warning: This repo is stale, all new features will be added on https://github.com/pagopa/terraform-azurerm-v3 :warning:

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

### Motivation and context

the `kubernetes.io/ingress.class` is deprecated for `ingressClassName` see:  https://kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation

### Type of changes

- [ ] Add new module
- [ ] Update existing module
- [ ] Remove existing module

### Does this introduce a breaking change?

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

### Run checks

Useful commands to run checks on local machine

```sh
bash .utils/terraform_run_all.sh init local
pre-commit run -a
```
