### PR TITLE
fix: Removed kubernetes.io/ingress.class from elk-module

### DIFF
--- a/elastic_stack/yaml/ingress_apm.yaml
+++ b/elastic_stack/yaml/ingress_apm.yaml
@@ -4,7 +4,6 @@ metadata:
   name: apm
   namespace: ${namespace}
   annotations:
-    kubernetes.io/ingress.class: nginxelk
     nginx.ingress.kubernetes.io/rewrite-target: /$2
     nginx.ingress.kubernetes.io/ssl-redirect: 'false'
     nginx.ingress.kubernetes.io/use-regex: 'true'

--- a/elastic_stack/yaml/ingress_elastic.yaml
+++ b/elastic_stack/yaml/ingress_elastic.yaml
@@ -4,7 +4,6 @@ metadata:
   name: elastic
   namespace: ${namespace}
   annotations:
-    kubernetes.io/ingress.class: nginxelk
     nginx.ingress.kubernetes.io/rewrite-target: /$2
     nginx.ingress.kubernetes.io/ssl-redirect: 'false'
     nginx.ingress.kubernetes.io/use-regex: 'true'

--- a/elastic_stack/yaml/ingress_kibana.yaml
+++ b/elastic_stack/yaml/ingress_kibana.yaml
@@ -4,7 +4,6 @@ metadata:
   name: kibana
   namespace: ${namespace}
   annotations:
-    kubernetes.io/ingress.class: nginxelk
     nginx.ingress.kubernetes.io/rewrite-target: /$2
     nginx.ingress.kubernetes.io/ssl-redirect: 'false'
     nginx.ingress.kubernetes.io/use-regex: 'true'


### PR DESCRIPTION
### :warning: This repo is stale, all new features will be added on https://github.com/pagopa/terraform-azurerm-v3 :warning:

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

### Motivation and context

kubernetes.io/ingress.class is deprecated, now we need to use ingressClassName

### Type of changes

- [ ] Add new module
- [x] Update existing module
- [ ] Remove existing module

### Does this introduce a breaking change?

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

### Run checks

Useful commands to run checks on local machine

```sh
bash .utils/terraform_run_all.sh init local
pre-commit run -a
```
