### PR TITLE
fix: Add variable advanced_threat_protection to cdn

### DIFF
--- a/cdn/main.tf
+++ b/cdn/main.tf
@@ -24,6 +24,8 @@ module "cdn_storage_account" {
   lock_name    = format("%s-%s-sa-lock", var.prefix, var.name)
   lock_level   = "CanNotDelete"
   lock_notes   = null
+  
+  advanced_threat_protection = var.advanced_threat_protection
 
   tags = var.tags
 }

--- a/cdn/variables.tf
+++ b/cdn/variables.tf
@@ -332,3 +332,9 @@ variable "dns_zone_name" {
 variable "dns_zone_resource_group_name" {
   type = string
 }
+
+variable "advanced_threat_protection" {
+  type        = string
+  default     = false
+  description = "Should Advanced Threat Protection be enabled on this resource?"
+}


### PR DESCRIPTION
### :warning: This repo is stale, all new features will be added on https://github.com/pagopa/terraform-azurerm-v3 :warning:

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
Adding new variable for cdn when define storage account 

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new module
- [X] Update existing module
- [ ] Remove existing module

### Does this introduce a breaking change?

- [ ] Yes
- [X] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

### Run checks

Useful commands to run checks on local machine

```sh
bash .utils/terraform_run_all.sh init local
pre-commit run -a
```
